### PR TITLE
Поддержка сразу всех версий Revit.

### DIFF
--- a/Revit.AddinSwitcher.Tests/Revit.AddinSwitcher.Tests.csproj
+++ b/Revit.AddinSwitcher.Tests/Revit.AddinSwitcher.Tests.csproj
@@ -1,0 +1,30 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>net9.0-windows</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+		<IsPackable>false</IsPackable>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="coverlet.collector" Version="6.0.2" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+		<PackageReference Include="xunit" Version="2.9.2" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+		<PackageReference Include="AutoFixture" Version="4.18.1" />
+		<PackageReference Include="AutoFixture.AutoMoq" Version="4.18.1" />
+		<PackageReference Include="AutoFixture.Xunit2" Version="4.18.1" />
+		<PackageReference Include="FluentAssertions" Version="8.2.0" />
+		<PackageReference Include="Moq" Version="4.20.72" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\src\Revit.AddinSwitcher\Revit.AddinSwitcher.csproj" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<Using Include="Xunit" />
+	</ItemGroup>
+
+</Project>

--- a/Revit.AddinSwitcher.Tests/UnitTest1.cs
+++ b/Revit.AddinSwitcher.Tests/UnitTest1.cs
@@ -1,0 +1,10 @@
+﻿namespace Revit.AddinSwitcher.Tests;
+
+public class UnitTest1
+{
+    [Fact]
+    public void Test1()
+    {
+
+    }
+}

--- a/revit.addinSwitcher.sln
+++ b/revit.addinSwitcher.sln
@@ -10,6 +10,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.editorconfig = .editorconfig
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Revit.AddinSwitcher.Tests", "Revit.AddinSwitcher.Tests\Revit.AddinSwitcher.Tests.csproj", "{3CE17EEF-C9E9-43BD-8FAD-A71079B1A3FF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -20,6 +22,10 @@ Global
 		{6A490626-13B4-409C-9076-CB2CAC93B75D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6A490626-13B4-409C-9076-CB2CAC93B75D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6A490626-13B4-409C-9076-CB2CAC93B75D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3CE17EEF-C9E9-43BD-8FAD-A71079B1A3FF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3CE17EEF-C9E9-43BD-8FAD-A71079B1A3FF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3CE17EEF-C9E9-43BD-8FAD-A71079B1A3FF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3CE17EEF-C9E9-43BD-8FAD-A71079B1A3FF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Revit.AddinSwitcher/Abstractions/ViewModels/AddinInfoViewModel.cs
+++ b/src/Revit.AddinSwitcher/Abstractions/ViewModels/AddinInfoViewModel.cs
@@ -8,7 +8,24 @@ internal sealed record AddinInfoViewModel(string Path, bool IsActive)
         ?? string.Empty;
     public string DirectoryPath => System.IO.Path.GetDirectoryName(Path) 
         ?? string.Empty;
-    public string? Version => Directory.Exists(DirectoryPath) 
-        ? new DirectoryInfo(DirectoryPath).Name 
-        : string.Empty;
+    public string? Version
+    {
+        get
+        {
+            if (Directory.Exists(DirectoryPath))
+            {
+                string? hostDirectoryName = new DirectoryInfo(DirectoryPath).Name;
+                if (int.TryParse(hostDirectoryName, out _))
+                    return hostDirectoryName;
+                else
+                {
+                    hostDirectoryName = new DirectoryInfo(DirectoryPath).Parent?.Name;
+                    if (int.TryParse(hostDirectoryName, out _))
+                        return hostDirectoryName;
+                }
+                
+            }
+            return string.Empty;
+        }
+    }
 }

--- a/src/Revit.AddinSwitcher/MainWindow.xaml
+++ b/src/Revit.AddinSwitcher/MainWindow.xaml
@@ -64,6 +64,12 @@
 
         </DataTemplate>
 
+        <DataTemplate DataType="{x:Type viewModels:AddinInfoVersionFilterViewModel}">
+
+            <TextBlock Text="{Binding Value}" />
+
+        </DataTemplate>
+
         <DataTemplate DataType="{x:Type viewModels:ActivatedAddinPathContainerViewModel}">
 
             <Grid>
@@ -75,6 +81,7 @@
                 </interaction:Interaction.Triggers>
 
                 <Grid.RowDefinitions>
+                    <RowDefinition Height="auto" />
                     <RowDefinition Height="auto" />
                     <RowDefinition Height="*" />
                 </Grid.RowDefinitions>
@@ -110,6 +117,20 @@
 
                 <ListBox
                     Grid.Row="1"
+                    DataContext="{Binding Filters}"
+                    ItemsSource="{Binding}"
+                    Style="{StaticResource MaterialDesignFilterChipSecondaryListBox}">
+
+                    <ListBox.ItemContainerStyle>
+                        <Style BasedOn="{StaticResource MaterialDesignFilterChipSecondaryListBoxItem}" TargetType="{x:Type ListBoxItem}">
+                            <Setter Property="IsSelected" Value="{Binding IsActive, Mode=TwoWay}" />
+                        </Style>
+                    </ListBox.ItemContainerStyle>
+
+                </ListBox>
+
+                <ListBox
+                    Grid.Row="2"
                     ItemsSource="{Binding CollectionViewSource.View}"
                     SelectionMode="Multiple">
 
@@ -138,6 +159,7 @@
 
                 <Grid.RowDefinitions>
                     <RowDefinition Height="auto" />
+                    <RowDefinition Height="auto" />
                     <RowDefinition Height="*" />
                 </Grid.RowDefinitions>
 
@@ -172,6 +194,20 @@
 
                 <ListBox
                     Grid.Row="1"
+                    DataContext="{Binding Filters}"
+                    ItemsSource="{Binding}"
+                    Style="{StaticResource MaterialDesignFilterChipSecondaryListBox}">
+
+                    <ListBox.ItemContainerStyle>
+                        <Style BasedOn="{StaticResource MaterialDesignFilterChipSecondaryListBoxItem}" TargetType="{x:Type ListBoxItem}">
+                            <Setter Property="IsSelected" Value="{Binding IsActive, Mode=TwoWay}" />
+                        </Style>
+                    </ListBox.ItemContainerStyle>
+
+                </ListBox>
+
+                <ListBox
+                    Grid.Row="2"
                     ItemsSource="{Binding CollectionViewSource.View}"
                     SelectionMode="Multiple">
 

--- a/src/Revit.AddinSwitcher/MainWindow.xaml
+++ b/src/Revit.AddinSwitcher/MainWindow.xaml
@@ -11,7 +11,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:viewModels="clr-namespace:Revit.AddinSwitcher.ViewModels"
     Title="{Binding Localizer[mainwindow_title]}"
-    Width="900"
+    Width="910"
     Height="700"
     DataContext="{Binding MainWindow, Source={StaticResource Locator}}"
     ToolTip="{Binding Localizer[mainwindow_tooltip]}"

--- a/src/Revit.AddinSwitcher/ViewModels/ActivatedAddinPathContainerViewModel.cs
+++ b/src/Revit.AddinSwitcher/ViewModels/ActivatedAddinPathContainerViewModel.cs
@@ -4,6 +4,7 @@ using Revit.AddinSwitcher.Abstractions.ViewModels;
 using Revit.AddinSwitcher.Infrastructure;
 using Revit.AddinSwitcher.ViewModels.Base;
 using System.Collections.ObjectModel;
+using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Windows.Data;
 
@@ -19,7 +20,18 @@ internal sealed partial class ActivatedAddinPathContainerViewModel : Initializab
     private void OnInitialing() => RefreshCollectionView();
 
     [ObservableProperty]
-    private string _searchField;
+    private string _searchField = string.Empty;
+
+    public IEnumerable<AddinInfoVersionFilterViewModel> _filters = [
+        new(true, "2021"),
+        new(true, "2022"),
+        new(true, "2023"),
+        new(true, "2024"),
+        new(true, "2025"),
+        new(true, "2026"),
+        //new(true, nameof(AddinInfoViewModel.Version), "Все"),
+        ];
+    public IEnumerable<AddinInfoVersionFilterViewModel> Filters => _filters;
 
     public ObservableCollection<AddinInfoViewModel> SelectedItems
         => CollectionViewSource is not null
@@ -36,6 +48,10 @@ internal sealed partial class ActivatedAddinPathContainerViewModel : Initializab
     {
         _ownerContainer.PropertyChanged += AddinPathContainerViewModel_PropertyChanged;
         PropertyChanged += ActivatedAddinPathContainerViewModel_PropertyChanged;
+        foreach (var filter in Filters)
+        {
+            filter.PropertyChanged += Filter_PropertyChanged;
+        }
     }
 
 
@@ -43,11 +59,19 @@ internal sealed partial class ActivatedAddinPathContainerViewModel : Initializab
     {
         _ownerContainer.PropertyChanged -= AddinPathContainerViewModel_PropertyChanged;
         PropertyChanged -= ActivatedAddinPathContainerViewModel_PropertyChanged;
+        foreach (var filter in Filters)
+        {
+            filter.PropertyChanged -= Filter_PropertyChanged;
+        }
+
     }
+    private void Filter_PropertyChanged(object? sender, PropertyChangedEventArgs e) => RefreshCollectionView();
 
     private void ActivatedAddinPathContainerViewModel_PropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
         if (e.PropertyName == nameof(SearchField))
+            RefreshCollectionView();
+        if (e.PropertyName == nameof(Filters))
             RefreshCollectionView();
     }
     private void AddinPathContainerViewModel_PropertyChanged(object? sender, PropertyChangedEventArgs args)
@@ -80,7 +104,10 @@ internal sealed partial class ActivatedAddinPathContainerViewModel : Initializab
     private void CollectionViewSource_Filter(object sender, FilterEventArgs args)
     {
         args.Accepted = args.Item is SelectableViewModel<AddinInfoViewModel> viewModel
-            && viewModel.Item is not null && IsTarget(viewModel.Item) && viewModel.Item.Path.Contains(SearchField ?? string.Empty);
+            && viewModel.Item is not null && IsTarget(viewModel.Item)
+            && Filters.Where(i => i.IsActive).Any(filter => filter.IsValid(viewModel.Item))
+            && viewModel.Item.Path.Contains(SearchField ?? string.Empty);
+
     }
     private static bool IsTarget(AddinInfoViewModel item) => item.IsActive is true;
 }

--- a/src/Revit.AddinSwitcher/ViewModels/AddinInfoFilterViewModel.cs
+++ b/src/Revit.AddinSwitcher/ViewModels/AddinInfoFilterViewModel.cs
@@ -1,0 +1,23 @@
+﻿using CommunityToolkit.Mvvm.ComponentModel;
+using Revit.AddinSwitcher.Abstractions.ViewModels;
+
+namespace Revit.AddinSwitcher.ViewModels;
+
+internal sealed partial class AddinInfoVersionFilterViewModel : ObservableObject
+{
+    public AddinInfoVersionFilterViewModel(bool isActive, string value)
+    {
+        IsActive = isActive;
+        Value = value;
+    }
+
+    [ObservableProperty]
+    public bool _isActive;
+
+    public string Value { get; init; }
+
+    public bool IsValid(AddinInfoViewModel item) => item.Version == Value;
+
+
+    public override string? ToString() => Value?.ToString();
+}

--- a/src/Revit.AddinSwitcher/ViewModels/DeactivatedAddinPathContainerViewModel.cs
+++ b/src/Revit.AddinSwitcher/ViewModels/DeactivatedAddinPathContainerViewModel.cs
@@ -4,6 +4,7 @@ using Revit.AddinSwitcher.Abstractions.ViewModels;
 using Revit.AddinSwitcher.Infrastructure;
 using Revit.AddinSwitcher.ViewModels.Base;
 using System.Collections.ObjectModel;
+using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Windows.Data;
 
@@ -21,6 +22,17 @@ internal sealed partial class DeactivatedAddinPathContainerViewModel : Initializ
     [ObservableProperty]
     private string _searchField = string.Empty;
 
+    public IEnumerable<AddinInfoVersionFilterViewModel> _filters = [
+        new(true, "2021"),
+        new(true, "2022"),
+        new(true, "2023"),
+        new(true, "2024"),
+        new(true, "2025"),
+        new(true, "2026"),
+        //new(true, nameof(AddinInfoViewModel.Version), "Все"),
+        ];
+    public IEnumerable<AddinInfoVersionFilterViewModel> Filters => _filters;
+
     public ObservableCollection<AddinInfoViewModel> SelectedItems
         => CollectionViewSource is not null
         ? ((ObservableCollection<SelectableViewModel<AddinInfoViewModel>>)CollectionViewSource.Source)
@@ -36,6 +48,10 @@ internal sealed partial class DeactivatedAddinPathContainerViewModel : Initializ
     {
         _ownerContainer.PropertyChanged += AddinPathContainerViewModel_PropertyChanged;
         PropertyChanged += ActivatedAddinPathContainerViewModel_PropertyChanged;
+        foreach (var filter in Filters)
+        {
+            filter.PropertyChanged += Filter_PropertyChanged;
+        }
     }
 
 
@@ -43,11 +59,19 @@ internal sealed partial class DeactivatedAddinPathContainerViewModel : Initializ
     {
         _ownerContainer.PropertyChanged -= AddinPathContainerViewModel_PropertyChanged;
         PropertyChanged -= ActivatedAddinPathContainerViewModel_PropertyChanged;
+        foreach (var filter in Filters)
+        {
+            filter.PropertyChanged -= Filter_PropertyChanged;
+        }
+
     }
+    private void Filter_PropertyChanged(object? sender, PropertyChangedEventArgs e) => RefreshCollectionView();
 
     private void ActivatedAddinPathContainerViewModel_PropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
         if (e.PropertyName == nameof(SearchField))
+            RefreshCollectionView();
+        if (e.PropertyName == nameof(Filters))
             RefreshCollectionView();
     }
     private void AddinPathContainerViewModel_PropertyChanged(object? sender, PropertyChangedEventArgs args)
@@ -81,7 +105,9 @@ internal sealed partial class DeactivatedAddinPathContainerViewModel : Initializ
     private void CollectionViewSource_Filter(object sender, FilterEventArgs args)
     {
         args.Accepted = args.Item is SelectableViewModel<AddinInfoViewModel> viewModel
-            && viewModel.Item is not null && IsTarget(viewModel.Item) && viewModel.Item.Path.Contains(SearchField ?? string.Empty);
+            && viewModel.Item is not null && IsTarget(viewModel.Item)
+            && Filters.Where(i => i.IsActive).Any(filter => filter.IsValid(viewModel.Item))
+            && viewModel.Item.Path.Contains(SearchField ?? string.Empty);
     }
     private static bool IsTarget(AddinInfoViewModel item) => item.IsActive is false;
 }

--- a/src/Revit.AddinSwitcher/ViewModels/DeactivatedAddinPathContainerViewModel.cs
+++ b/src/Revit.AddinSwitcher/ViewModels/DeactivatedAddinPathContainerViewModel.cs
@@ -4,7 +4,6 @@ using Revit.AddinSwitcher.Abstractions.ViewModels;
 using Revit.AddinSwitcher.Infrastructure;
 using Revit.AddinSwitcher.ViewModels.Base;
 using System.Collections.ObjectModel;
-using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Windows.Data;
 

--- a/src/Revit.AddinSwitcher/ViewModels/RefreshAddinPathContainerViewModel.cs
+++ b/src/Revit.AddinSwitcher/ViewModels/RefreshAddinPathContainerViewModel.cs
@@ -94,7 +94,6 @@ internal sealed partial class RefreshAddinPathContainerViewModel : Initializable
         => _debounceDispatcher.Debounce(2000, args => RefreshInfoAboutAddins(), args);
     private void OnError(object sender, ErrorEventArgs args)
         => _debounceDispatcher.Debounce(2000, args => RefreshInfoAboutAddins(), args);
-
     private void RefreshInfoAboutAddins()
     {
         IEnumerable<string> directories = _directoryContainer.Collection

--- a/src/Revit.AddinSwitcher/ViewModels/TargetAddinDirectoryPathContainerViewModel.cs
+++ b/src/Revit.AddinSwitcher/ViewModels/TargetAddinDirectoryPathContainerViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
 using Microsoft.Extensions.Logging;
 using Revit.AddinSwitcher.Abstractions.ViewModels;
+using Revit.AddinSwitcher.Infrastructure;
 using System.Collections.ObjectModel;
 using System.IO;
 
@@ -23,11 +24,18 @@ internal sealed partial class TargetAddinDirectoryPathContainerViewModel : Initi
     private readonly string _commonAppPath = Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData);
 
     [AutoConstructorInitializer]
-    private void OnInitialing() => Collection = [
-            new(Path.Combine(_appPath, @$"Autodesk\Revit\Addins\2021")),
-            new(Path.Combine(_commonAppPath, @$"Autodesk\Revit\Addins\2021"))
-        ];
+    private void OnInitialing()
+    {
+        IEnumerable<string> addinDirectoryPaths = [
+                Path.Combine(_appPath, @$"Autodesk\Revit\Addins\"),
+                Path.Combine(_commonAppPath, @$"Autodesk\Revit\Addins\")
+            ];
+        IEnumerable<DirectoryInfoViewModel> collection = addinDirectoryPaths
+            .SelectMany(Directory.GetDirectories)
+            .Select(directoryPath => new DirectoryInfoViewModel(directoryPath));
 
+        Collection = collection.ToObservable();
+    }
 
     [ObservableProperty]
     private ObservableCollection<DirectoryInfoViewModel> _collection = [];


### PR DESCRIPTION
- Вместо статически определенных директорий с манифестами плагинов, теперь вычисление идет при запуске, тем самым алгоритм сразу находит манифесты для всех версий revit.
- Реализация фильтров, позволяющих пользователю отсеивать манифесты плагинов их принадлежности в конкретной версии Revit.